### PR TITLE
Add database models and migrations (issue #7)

### DIFF
--- a/backend/AutoShop/Gemfile
+++ b/backend/AutoShop/Gemfile
@@ -20,7 +20,19 @@ gem "jbuilder"
 gem "fiddle"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
+
+# JWT tokens for authentication (Auth/Basket/Admin endpoints)
+gem "jwt", "~> 2.8"
+
+# CORS support for the React (Vite) frontend
+gem "rack-cors", "~> 2.0"
+
+# Pagination for catalog/search/admin endpoints (page size = 20)
+gem "kaminari", "~> 1.2"
+
+# Read environment variables from .env file (see CONTRIBUTING.md)
+gem "dotenv-rails", "~> 3.1", groups: [:development, :test]
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/backend/AutoShop/Gemfile.lock
+++ b/backend/AutoShop/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.22)
     bcrypt_pbkdf (1.1.2)
     bigdecimal (4.1.1)
     bindex (0.8.1)
@@ -107,6 +108,9 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     dotenv (3.2.0)
+    dotenv-rails (3.2.0)
+      dotenv (= 3.2.0)
+      railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
     erb (6.0.2)
@@ -140,6 +144,8 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.19.3)
+    jwt (2.10.3)
+      base64
     kamal (2.11.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -151,6 +157,18 @@ GEM
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
       zeitwerk (>= 2.6.18, < 3.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -215,6 +233,8 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-cors (2.0.2)
+      rack (>= 2.0.0)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -363,19 +383,24 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   bundler-audit
   capybara
   debug
+  dotenv-rails (~> 3.1)
   fiddle
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
+  jwt (~> 2.8)
   kamal
+  kaminari (~> 1.2)
   pg (~> 1.1)
   propshaft
   puma (>= 5.0)
+  rack-cors (~> 2.0)
   rails (~> 8.1.3)
   rubocop-rails-omakase
   selenium-webdriver
@@ -404,6 +429,7 @@ CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bcrypt (3.1.22) sha256=1f0072e88c2d705d94aff7f2c5cb02eb3f1ec4b8368671e19112527489f29032
   bcrypt_pbkdf (1.1.2) sha256=c2414c23ce66869b3eb9f643d6a3374d8322dfb5078125c82792304c10b94cf6
   bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
@@ -418,6 +444,7 @@ CHECKSUMS
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
+  dotenv-rails (3.2.0) sha256=657e25554ba622ffc95d8c4f1670286510f47f2edda9f68293c3f661b303beab
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   erb (6.0.2) sha256=9fe6264d44f79422c87490a1558479bd0e7dad4dd0e317656e67ea3077b5242b
@@ -435,7 +462,12 @@ CHECKSUMS
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
+  jwt (2.10.3) sha256=e4d9352fbc7309b1a7448c7dd713dfe4d8c47077af80759cdbed8f878ea0b484
   kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
+  kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
+  kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
+  kaminari-activerecord (1.2.2) sha256=0dd3a67bab356a356f36b3b7236bcb81cef313095365befe8e98057dd2472430
+  kaminari-core (1.2.2) sha256=3bd26fec7370645af40ca73b9426a448d09b8a8ba7afa9ba3c3e0d39cdbb83ff
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -472,6 +504,7 @@ CHECKSUMS
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
+  rack-cors (2.0.2) sha256=415d4e1599891760c5dc9ef0349c7fecdf94f7c6a03e75b2e7c2b54b82adda1b
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
   rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868

--- a/backend/AutoShop/app/models/account.rb
+++ b/backend/AutoShop/app/models/account.rb
@@ -1,0 +1,29 @@
+class Account < ApplicationRecord
+  EMAIL_REGEXP = URI::MailTo::EMAIL_REGEXP
+
+  has_secure_password
+
+  enum :role, { user: 0, admin: 1 }, default: :user
+
+  has_one  :basket, dependent: :destroy
+  has_many :orders, dependent: :destroy
+
+  before_validation :normalize_email
+  after_create :ensure_basket
+
+  validates :email,
+            presence: true,
+            format: { with: EMAIL_REGEXP },
+            uniqueness: { case_sensitive: false }
+  validates :password, length: { in: 6..128 }, if: -> { password.present? }
+
+  private
+
+  def normalize_email
+    self.email = email.to_s.strip.downcase.presence
+  end
+
+  def ensure_basket
+    create_basket! unless basket
+  end
+end

--- a/backend/AutoShop/app/models/basket.rb
+++ b/backend/AutoShop/app/models/basket.rb
@@ -1,0 +1,20 @@
+class Basket < ApplicationRecord
+  belongs_to :account
+
+  has_many :basket_items, dependent: :destroy
+  has_many :products,     through:  :basket_items
+
+  validates :account_id, uniqueness: true
+
+  def total_amount
+    basket_items.includes(:product).sum { |item| item.quantity * item.product.effective_cost }
+  end
+
+  def total_items_count
+    basket_items.sum(:quantity)
+  end
+
+  def clear!
+    basket_items.destroy_all
+  end
+end

--- a/backend/AutoShop/app/models/basket_item.rb
+++ b/backend/AutoShop/app/models/basket_item.rb
@@ -1,0 +1,7 @@
+class BasketItem < ApplicationRecord
+  belongs_to :basket
+  belongs_to :product
+
+  validates :product_id, uniqueness: { scope: :basket_id }
+  validates :quantity,   numericality: { only_integer: true, greater_than: 0 }
+end

--- a/backend/AutoShop/app/models/category.rb
+++ b/backend/AutoShop/app/models/category.rb
@@ -1,0 +1,17 @@
+class Category < ApplicationRecord
+  has_many :products, dependent: :restrict_with_error
+
+  before_validation :generate_slug, if: -> { slug.blank? && name.present? }
+
+  validates :name,     presence: true, length: { maximum: 100 }
+  validates :slug,     presence: true, uniqueness: true, length: { maximum: 100 }
+  validates :position, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  default_scope { order(:position, :id) }
+
+  private
+
+  def generate_slug
+    self.slug = name.to_s.parameterize
+  end
+end

--- a/backend/AutoShop/app/models/jwt_denylist.rb
+++ b/backend/AutoShop/app/models/jwt_denylist.rb
@@ -1,0 +1,20 @@
+class JwtDenylist < ApplicationRecord
+  self.table_name = "jwt_denylist"
+
+  validates :jti,        presence: true, uniqueness: true
+  validates :expires_at, presence: true
+
+  scope :active, -> { where("expires_at > ?", Time.current) }
+
+  def self.revoked?(jti)
+    active.exists?(jti: jti)
+  end
+
+  def self.revoke!(jti:, expires_at:)
+    create!(jti: jti, expires_at: expires_at)
+  end
+
+  def self.purge_expired!
+    where("expires_at <= ?", Time.current).delete_all
+  end
+end

--- a/backend/AutoShop/app/models/order.rb
+++ b/backend/AutoShop/app/models/order.rb
@@ -1,0 +1,23 @@
+class Order < ApplicationRecord
+  PHONE_REGEXP = /\A\+?\d{10,15}\z/
+  EMAIL_REGEXP = URI::MailTo::EMAIL_REGEXP
+
+  belongs_to :account
+
+  has_many :order_items, dependent: :destroy
+
+  enum :status,
+       { pending: 0, processing: 1, shipped: 2, delivered: 3, cancelled: 4 },
+       default: :pending
+
+  validates :name,    presence: true, length: { in: 2..100 }
+  validates :phone,   presence: true, format: { with: PHONE_REGEXP }
+  validates :email,   presence: true, format: { with: EMAIL_REGEXP }
+  validates :address, presence: true, length: { maximum: 300 }
+  validates :comment, length: { maximum: 500 }, allow_blank: true
+  validates :total_amount,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :order_items, length: { minimum: 1, message: "must contain at least one item" }
+
+  scope :recent, -> { order(created_at: :desc) }
+end

--- a/backend/AutoShop/app/models/order_item.rb
+++ b/backend/AutoShop/app/models/order_item.rb
@@ -1,0 +1,12 @@
+class OrderItem < ApplicationRecord
+  belongs_to :order
+  belongs_to :product, optional: true
+
+  validates :name,     presence: true, length: { maximum: 255 }
+  validates :quantity, numericality: { only_integer: true, greater_than: 0 }
+  validates :cost,     numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  def subtotal
+    quantity * cost
+  end
+end

--- a/backend/AutoShop/app/models/product.rb
+++ b/backend/AutoShop/app/models/product.rb
@@ -1,0 +1,29 @@
+class Product < ApplicationRecord
+  NO_SALE = -1
+
+  belongs_to :category
+
+  has_many :basket_items, dependent: :destroy
+  has_many :baskets,      through:  :basket_items
+  has_many :order_items,  dependent: :nullify
+
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :cost, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+  validates :sale_cost,
+            numericality: { only_integer: true, greater_than_or_equal_to: -1 }
+  validates :description, length: { maximum: 5_000 }, allow_blank: true
+  validates :picture,     length: { maximum: 500 },   allow_blank: true
+  validates :stock, inclusion: { in: [true, false] }
+
+  scope :in_stock,    -> { where(stock: true) }
+  scope :by_category, ->(category_id) { where(category_id: category_id) }
+  scope :search,      ->(query) { where("LOWER(name) LIKE ?", "%#{query.to_s.downcase}%") }
+
+  def on_sale?
+    sale_cost.to_i >= 0 && sale_cost < cost
+  end
+
+  def effective_cost
+    on_sale? ? sale_cost : cost
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200001_create_accounts.rb
+++ b/backend/AutoShop/db/migrate/20260601200001_create_accounts.rb
@@ -1,0 +1,14 @@
+class CreateAccounts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :accounts do |t|
+      t.string  :email,           null: false
+      t.string  :password_digest, null: false
+      t.integer :role,            null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :accounts, "LOWER(email)", unique: true, name: "index_accounts_on_lower_email"
+    add_index :accounts, :role
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200002_create_categories.rb
+++ b/backend/AutoShop/db/migrate/20260601200002_create_categories.rb
@@ -1,0 +1,15 @@
+class CreateCategories < ActiveRecord::Migration[8.1]
+  def change
+    create_table :categories do |t|
+      t.string  :name,     null: false
+      t.string  :slug,     null: false
+      t.string  :image
+      t.integer :position, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :categories, :slug, unique: true
+    add_index :categories, :position
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200003_create_products.rb
+++ b/backend/AutoShop/db/migrate/20260601200003_create_products.rb
@@ -1,0 +1,18 @@
+class CreateProducts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :products do |t|
+      t.string     :name,        null: false
+      t.integer    :cost,        null: false
+      t.integer    :sale_cost,   null: false, default: -1
+      t.string     :picture
+      t.text       :description
+      t.boolean    :stock,       null: false, default: true
+      t.references :category,    null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :products, :name
+    add_index :products, :stock
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200004_create_baskets.rb
+++ b/backend/AutoShop/db/migrate/20260601200004_create_baskets.rb
@@ -1,0 +1,9 @@
+class CreateBaskets < ActiveRecord::Migration[8.1]
+  def change
+    create_table :baskets do |t|
+      t.references :account, null: false, foreign_key: true, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200005_create_basket_items.rb
+++ b/backend/AutoShop/db/migrate/20260601200005_create_basket_items.rb
@@ -1,0 +1,14 @@
+class CreateBasketItems < ActiveRecord::Migration[8.1]
+  def change
+    create_table :basket_items do |t|
+      t.references :basket,   null: false, foreign_key: true
+      t.references :product,  null: false, foreign_key: true
+      t.integer    :quantity, null: false, default: 1
+
+      t.timestamps
+    end
+
+    add_index :basket_items, %i[basket_id product_id], unique: true
+    add_check_constraint :basket_items, "quantity > 0", name: "basket_items_quantity_positive"
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200006_create_orders.rb
+++ b/backend/AutoShop/db/migrate/20260601200006_create_orders.rb
@@ -1,0 +1,20 @@
+class CreateOrders < ActiveRecord::Migration[8.1]
+  def change
+    create_table :orders do |t|
+      t.references :account,      null: false, foreign_key: true
+      t.string     :name,         null: false
+      t.string     :phone,        null: false
+      t.string     :email,        null: false
+      t.text       :comment
+      t.string     :address,      null: false
+      t.integer    :status,       null: false, default: 0
+      t.integer    :total_amount, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :orders, :status
+    add_index :orders, :created_at
+    add_check_constraint :orders, "total_amount >= 0", name: "orders_total_amount_non_negative"
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200007_create_order_items.rb
+++ b/backend/AutoShop/db/migrate/20260601200007_create_order_items.rb
@@ -1,0 +1,16 @@
+class CreateOrderItems < ActiveRecord::Migration[8.1]
+  def change
+    create_table :order_items do |t|
+      t.references :order,    null: false, foreign_key: true
+      t.references :product,  foreign_key: true
+      t.string     :name,     null: false
+      t.integer    :quantity, null: false
+      t.integer    :cost,     null: false
+
+      t.timestamps
+    end
+
+    add_check_constraint :order_items, "quantity > 0", name: "order_items_quantity_positive"
+    add_check_constraint :order_items, "cost >= 0",    name: "order_items_cost_non_negative"
+  end
+end

--- a/backend/AutoShop/db/migrate/20260601200008_create_jwt_denylist.rb
+++ b/backend/AutoShop/db/migrate/20260601200008_create_jwt_denylist.rb
@@ -1,0 +1,13 @@
+class CreateJwtDenylist < ActiveRecord::Migration[8.1]
+  def change
+    create_table :jwt_denylist do |t|
+      t.string   :jti,        null: false
+      t.datetime :expires_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :jwt_denylist, :jti, unique: true
+    add_index :jwt_denylist, :expires_at
+  end
+end

--- a/backend/AutoShop/db/schema.rb
+++ b/backend/AutoShop/db/schema.rb
@@ -1,0 +1,119 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 2026_06_01_200008) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "accounts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.string "password_digest", null: false
+    t.integer "role", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index "lower((email)::text)", name: "index_accounts_on_lower_email", unique: true
+    t.index ["role"], name: "index_accounts_on_role"
+  end
+
+  create_table "basket_items", force: :cascade do |t|
+    t.bigint "basket_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "product_id", null: false
+    t.integer "quantity", default: 1, null: false
+    t.datetime "updated_at", null: false
+    t.index ["basket_id", "product_id"], name: "index_basket_items_on_basket_id_and_product_id", unique: true
+    t.index ["basket_id"], name: "index_basket_items_on_basket_id"
+    t.index ["product_id"], name: "index_basket_items_on_product_id"
+    t.check_constraint "quantity > 0", name: "basket_items_quantity_positive"
+  end
+
+  create_table "baskets", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_baskets_on_account_id", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "image"
+    t.string "name", null: false
+    t.integer "position", default: 0, null: false
+    t.string "slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["position"], name: "index_categories_on_position"
+    t.index ["slug"], name: "index_categories_on_slug", unique: true
+  end
+
+  create_table "jwt_denylist", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "jti", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_jwt_denylist_on_expires_at"
+    t.index ["jti"], name: "index_jwt_denylist_on_jti", unique: true
+  end
+
+  create_table "order_items", force: :cascade do |t|
+    t.integer "cost", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "order_id", null: false
+    t.bigint "product_id"
+    t.integer "quantity", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_order_items_on_order_id"
+    t.index ["product_id"], name: "index_order_items_on_product_id"
+    t.check_constraint "cost >= 0", name: "order_items_cost_non_negative"
+    t.check_constraint "quantity > 0", name: "order_items_quantity_positive"
+  end
+
+  create_table "orders", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.string "address", null: false
+    t.text "comment"
+    t.datetime "created_at", null: false
+    t.string "email", null: false
+    t.string "name", null: false
+    t.string "phone", null: false
+    t.integer "status", default: 0, null: false
+    t.integer "total_amount", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_orders_on_account_id"
+    t.index ["created_at"], name: "index_orders_on_created_at"
+    t.index ["status"], name: "index_orders_on_status"
+    t.check_constraint "total_amount >= 0", name: "orders_total_amount_non_negative"
+  end
+
+  create_table "products", force: :cascade do |t|
+    t.bigint "category_id", null: false
+    t.integer "cost", null: false
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "name", null: false
+    t.string "picture"
+    t.integer "sale_cost", default: -1, null: false
+    t.boolean "stock", default: true, null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_products_on_category_id"
+    t.index ["name"], name: "index_products_on_name"
+    t.index ["stock"], name: "index_products_on_stock"
+  end
+
+  add_foreign_key "basket_items", "baskets"
+  add_foreign_key "basket_items", "products"
+  add_foreign_key "baskets", "accounts"
+  add_foreign_key "order_items", "orders"
+  add_foreign_key "order_items", "products"
+  add_foreign_key "orders", "accounts"
+  add_foreign_key "products", "categories"
+end

--- a/backend/AutoShop/db/seeds.rb
+++ b/backend/AutoShop/db/seeds.rb
@@ -1,9 +1,25 @@
 # This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Example:
-#
-#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
-#     MovieGenre.find_or_create_by!(name: genre_name)
-#   end
+
+categories = [
+  { slug: "akkumulyatori", name: "Аккумуляторы", position: 1, image: "/images/categories/akkumulyator.png" },
+  { slug: "avtomasla",     name: "Автомасла",    position: 2, image: "/images/categories/avtomaslo.png" },
+  { slug: "avtohimia",     name: "Автохимия",    position: 3, image: "/images/categories/avtohimia.png" },
+  { slug: "aksessuari",    name: "Аксессуары",   position: 4, image: "/images/categories/aksessuari.png" }
+]
+
+categories.each do |attrs|
+  Category.find_or_create_by!(slug: attrs[:slug]) do |category|
+    category.name     = attrs[:name]
+    category.position = attrs[:position]
+    category.image    = attrs[:image]
+  end
+end
+
+if Rails.env.development?
+  Account.find_or_create_by!(email: "admin@autoshop.local") do |account|
+    account.password = ENV.fetch("ADMIN_SEED_PASSWORD", "admin123")
+    account.role     = :admin
+  end
+end

--- a/docs/database/schema.md
+++ b/docs/database/schema.md
@@ -1,0 +1,229 @@
+# Схема БД AutoShop
+
+Документ описывает сущности БД для версии API **1.0.0** (см. [`docs/api/openapi.yaml`](../api/openapi.yaml)). Решает issue [#7](https://github.com/GHKaktus/AutoShop/issues/7).
+
+СУБД — **PostgreSQL** (порт 5432, конфиг в `backend/AutoShop/config/database.yml`). Все таблицы используют автоинкрементный `bigserial id` и стандартные Rails `created_at`/`updated_at`.
+
+## ER-диаграмма (упрощённая)
+
+```
+                +--------------+
+                |   accounts   |
+                +--------------+
+                | id           |
+                | email        |
+                | password_*** |
+                | role         |
+                +--------------+
+                  | 1     1 |
+       +----------+         +-----------+
+       |                                |
+       v 1                            * v
++--------------+                  +---------+
+|   baskets    |                  | orders  |
++--------------+                  +---------+
+| account_id   |                  | account_id
++--------------+                  | name/phone/email/comment/address
+       | 1                        | status/total_amount
+       |                          +---------+
+       v *                              | 1
++---------------+                       v *
+| basket_items  |                 +---------------+
++---------------+                 |  order_items  |
+| basket_id     |                 +---------------+
+| product_id    |                 | order_id      |
+| quantity      |                 | product_id?   |
++---------------+                 | name (snap)   |
+       | *                        | cost (snap)   |
+       v 1                        | quantity      |
++---------------+                 +---------------+
+|   products    | <--------------- product_id (nullable)
++---------------+
+| name/cost/sale_cost
+| picture/description
+| stock
+| category_id
++---------------+
+       | *
+       v 1
++---------------+
+|  categories   |
++---------------+
+| name/slug/image/position
++---------------+
+
+
++--------------+
+| jwt_denylist |   (отзыв JWT при logout)
++--------------+
+| jti (unique) |
+| expires_at   |
++--------------+
+```
+
+---
+
+## Таблицы
+
+### `accounts`
+Аккаунт пользователя. Соответствует схеме `Account` в OpenAPI.
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | Идентификатор |
+| `email` | string | NOT NULL, UNIQUE (по `LOWER(email)`) | Email — логин |
+| `password_digest` | string | NOT NULL | Хеш пароля (`bcrypt`, через `has_secure_password`) |
+| `role` | integer | NOT NULL, default `0` | `0 = user`, `1 = admin` (Rails enum) |
+| `created_at`, `updated_at` | timestamp | NOT NULL | Стандартные |
+
+**Индексы:** `LOWER(email)` (unique), `role`.
+
+### `categories`
+Категории каталога — нужны для эндпоинта `GET /catalog/{id}`. Базовые 4 категории создаются `db:seed`.
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | Идентификатор |
+| `name` | string | NOT NULL | Отображаемое имя (Аккумуляторы, …) |
+| `slug` | string | NOT NULL, UNIQUE | URL-идентификатор (`avtomasla`, …) |
+| `image` | string | NULL | Относительный путь к иконке |
+| `position` | integer | NOT NULL, default `0` | Порядок отображения |
+| `created_at`, `updated_at` | timestamp | NOT NULL | |
+
+### `products`
+Товар. Соответствует схеме `Product` в OpenAPI. Добавлено поле `category_id` для разбиения каталога.
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | |
+| `name` | string | NOT NULL | Название |
+| `cost` | integer | NOT NULL ≥ 0 | Цена в рублях |
+| `sale_cost` | integer | NOT NULL, default `-1` | Скидочная цена. `-1` ⇒ скидки нет |
+| `picture` | string | NULL | Относительный путь к картинке |
+| `description` | text | NULL | Описание |
+| `stock` | boolean | NOT NULL, default `true` | Есть ли на складе |
+| `category_id` | bigint | NOT NULL, FK → `categories.id` | |
+| `created_at`, `updated_at` | timestamp | NOT NULL | |
+
+**Индексы:** `category_id`, `name`, `stock`.
+
+### `baskets`
+Корзина — одна на пользователя. Создаётся автоматически после регистрации (`Account#after_create`).
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | |
+| `account_id` | bigint | NOT NULL, UNIQUE, FK → `accounts.id` | Владелец |
+| `created_at`, `updated_at` | timestamp | NOT NULL | |
+
+### `basket_items`
+Позиция корзины.
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | |
+| `basket_id` | bigint | NOT NULL, FK → `baskets.id` | |
+| `product_id` | bigint | NOT NULL, FK → `products.id` | |
+| `quantity` | integer | NOT NULL, default `1`, CHECK `> 0` | |
+| `created_at`, `updated_at` | timestamp | NOT NULL | |
+
+**Индексы:** UNIQUE `(basket_id, product_id)` — один товар не дублируется, только увеличивается `quantity`.
+
+### `orders`
+Заказ. Соответствует схеме `Order` в OpenAPI.
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | |
+| `account_id` | bigint | NOT NULL, FK → `accounts.id` | `user_id` в OpenAPI |
+| `name` | string | NOT NULL, 2..100 | Имя покупателя |
+| `phone` | string | NOT NULL, regex `^\+?\d{10,15}$` | Телефон |
+| `email` | string | NOT NULL, формат email | Email |
+| `comment` | text | NULL, до 500 символов | Комментарий |
+| `address` | string | NOT NULL, до 300 символов | Адрес доставки |
+| `status` | integer | NOT NULL, default `0` | `pending/processing/shipped/delivered/cancelled` |
+| `total_amount` | integer | NOT NULL ≥ 0 | Итоговая сумма в рублях (снапшот) |
+| `created_at`, `updated_at` | timestamp | NOT NULL | |
+
+**Индексы:** `account_id`, `status`, `created_at`.
+
+### `order_items`
+Позиция заказа. **Хранится снапшот** (`name`, `cost`) — заказ не «потеряется» при изменении/удалении товара. `product_id` опционален: при удалении товара заказ остаётся целым.
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | |
+| `order_id` | bigint | NOT NULL, FK → `orders.id` | |
+| `product_id` | bigint | NULL, FK → `products.id` | На случай удаления товара |
+| `name` | string | NOT NULL | Снапшот имени |
+| `quantity` | integer | NOT NULL, CHECK `> 0` | |
+| `cost` | integer | NOT NULL, CHECK `≥ 0` | Снапшот цены за единицу |
+| `created_at`, `updated_at` | timestamp | NOT NULL | |
+
+### `jwt_denylist`
+Отозванные JWT-токены (нужно для `POST /auth/logout`).
+
+| Поле | Тип | Ограничения | Описание |
+|------|-----|-------------|----------|
+| `id` | bigserial | PK | |
+| `jti` | string | NOT NULL, UNIQUE | JWT ID из payload |
+| `expires_at` | datetime | NOT NULL | Когда токен истекает (для очистки) |
+| `created_at`, `updated_at` | timestamp | NOT NULL | |
+
+Очистка устаревших записей: `JwtDenylist.purge_expired!` (можно вешать на cron / `solid_queue`).
+
+---
+
+## Связи (ActiveRecord)
+
+| Модель | Связь | Целевая модель | Опции |
+|--------|-------|----------------|-------|
+| `Account` | `has_one`     | `Basket` | `dependent: :destroy` |
+| `Account` | `has_many`    | `Order`  | `dependent: :destroy` |
+| `Basket`  | `belongs_to`  | `Account` | |
+| `Basket`  | `has_many`    | `BasketItem` | `dependent: :destroy` |
+| `BasketItem` | `belongs_to` | `Basket` | |
+| `BasketItem` | `belongs_to` | `Product` | |
+| `Category` | `has_many`   | `Product` | `dependent: :restrict_with_error` |
+| `Product` | `belongs_to`  | `Category` | |
+| `Product` | `has_many`    | `OrderItem` | `dependent: :nullify` |
+| `Order`   | `belongs_to`  | `Account` | |
+| `Order`   | `has_many`    | `OrderItem` | `dependent: :destroy` |
+| `OrderItem` | `belongs_to` | `Order` | |
+| `OrderItem` | `belongs_to` | `Product` | `optional: true` |
+
+---
+
+## Перечень миграций
+
+Все миграции лежат в `backend/AutoShop/db/migrate/`:
+
+1. `20260601200001_create_accounts.rb`
+2. `20260601200002_create_categories.rb`
+3. `20260601200003_create_products.rb`
+4. `20260601200004_create_baskets.rb`
+5. `20260601200005_create_basket_items.rb`
+6. `20260601200006_create_orders.rb`
+7. `20260601200007_create_order_items.rb`
+8. `20260601200008_create_jwt_denylist.rb`
+
+---
+
+## Применение
+
+```bash
+cd backend/AutoShop
+bundle install      # подтянет bcrypt, jwt, rack-cors, kaminari, dotenv-rails
+rails db:create
+rails db:migrate
+rails db:seed       # создаст 4 категории и admin@autoshop.local (только в dev)
+```
+
+---
+
+## Замечания и расширения на будущее
+
+* **`Account#role`** пока выдаётся хардкодом (по плану версии 1.0.0). В следующей итерации (issue [#12](https://github.com/GHKaktus/AutoShop/issues/12)) нужно будет добавить механизм назначения роли.
+* **`Product.picture`** хранит относительный путь (`/images/...`) — соответствует решению из issue [#8](https://github.com/GHKaktus/AutoShop/issues/8). При переходе на S3 заменим на Active Storage attachment (`image_processing` уже в Gemfile).
+* **Активные сессии**: вместо денилиста можно реализовать allowlist по `jti`, если потребуется управление списком активных устройств.
+* **Цены хранятся в `integer`** (рубли, как в OpenAPI). Если потребуются копейки — миграция `change_column :products, :cost, :integer` + домен пересчёта.


### PR DESCRIPTION
## Summary

- Implements issue #7: database entities aligned with OpenAPI 1.0.0 (Account, Product, Order and related tables).
- Adds 8 ActiveRecord models with associations and validations.
- Adds 8 migrations and `schema.rb` for PostgreSQL.
- Adds Gemfile dependencies for upcoming API work: bcrypt, jwt, rack-cors, kaminari, dotenv-rails.
- Seeds four catalog categories and a dev admin account.
- Documents the database schema in `docs/database/schema.md`.

Closes #7

## Test plan

- [ ] `cd backend/AutoShop && bundle install`
- [ ] `rails db:create db:migrate db:seed`
- [ ] Verify tables exist in PostgreSQL (accounts, categories, products, baskets, basket_items, orders, order_items, jwt_denylist)
- [ ] `rails runner "puts Category.count"` — expect 4 categories after seed
- [ ] `rails runner "puts Account.find_by(email: 'admin@autoshop.local').role"` — expect admin in development
