### PR TITLE
Реализовать API группы Auth (issue #9)

### DIFF
--- a/backend/AutoShop/app/controllers/api/auth_controller.rb
+++ b/backend/AutoShop/app/controllers/api/auth_controller.rb
@@ -1,0 +1,57 @@
+module Api
+  class AuthController < BaseController
+    before_action :authenticate_account!, only: :logout
+
+    def sign_up
+      account = Account.new(account_params)
+
+      if account.save
+        token = JwtService.encode(account: account)
+        render json: { token: token[:token] }, status: :created
+      else
+        render_validation_error(account)
+      end
+    end
+
+    def sign_in
+      account = Account.find_by("LOWER(email) = ?", params[:email].to_s.strip.downcase)
+
+      # Метод 'authenticate' предоставляется методом 'has_secure_password' из модели Account.
+
+      if account&.authenticate(params[:password])
+        token = JwtService.encode(account: account)
+        render json: { token: token[:token] }, status: :ok
+      else
+        render_error(
+          error:   "unauthorized",
+          message: "Неверный email или пароль",
+          status:  :unauthorized
+        )
+      end
+    end
+
+    def logout
+      JwtDenylist.revoke!(
+        jti:        current_token_payload[:jti],
+        expires_at: Time.at(current_token_payload[:exp].to_i)
+      )
+      head :ok
+    rescue ActiveRecord::RecordNotUnique
+      head :ok
+    end
+
+    private
+
+    def account_params
+      params.permit(:email, :password)
+    end
+
+    def render_validation_error(account)
+      render_error(
+        error:   "validation_error",
+        message: account.errors.full_messages.first || "Неверные данные",
+        status:  :bad_request
+      )
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/api/base_controller.rb
+++ b/backend/AutoShop/app/controllers/api/base_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  class BaseController < ActionController::API
+    include JwtAuthenticatable
+
+    rescue_from ActionController::ParameterMissing, with: :render_bad_request
+    rescue_from ActiveRecord::RecordNotFound,       with: :render_not_found
+
+    private
+
+    def render_error(error:, message:, status:)
+      render json: { error: error, message: message }, status: status
+    end
+
+    def render_bad_request(exception)
+      render_error(error: "bad_request", message: exception.message, status: :bad_request)
+    end
+
+    def render_not_found(_exception = nil)
+      render_error(error: "not_found", message: "Ресурс не найден", status: :not_found)
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/concerns/jwt_authenticatable.rb
+++ b/backend/AutoShop/app/controllers/concerns/jwt_authenticatable.rb
@@ -1,0 +1,46 @@
+module JwtAuthenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    attr_reader :current_account, :current_token_payload
+  end
+
+  def authenticate_account!
+    payload = decoded_token
+    return render_unauthorized("Неверный или отсутствующий токен") if payload.blank?
+
+    if JwtDenylist.revoked?(payload[:jti])
+      return render_unauthorized("Токен отозван")
+    end
+
+    account = Account.find_by(id: payload[:sub])
+    return render_unauthorized("Пользователь не найден") if account.nil?
+
+    @current_account       = account
+    @current_token_payload = payload
+  end
+
+  def require_admin!
+    return if current_account&.admin?
+
+    render json: { error: "forbidden", message: "Доступ запрещён" }, status: :forbidden
+  end
+
+  private
+
+  def decoded_token
+    header = request.headers["Authorization"].to_s
+    return nil unless header.start_with?("Bearer ")
+
+    token = header.split(" ", 2).last.to_s.strip
+    return nil if token.empty?
+
+    JwtService.decode(token)
+  rescue JwtService::DecodeError
+    nil
+  end
+
+  def render_unauthorized(message)
+    render json: { error: "unauthorized", message: message }, status: :unauthorized
+  end
+end

--- a/backend/AutoShop/app/services/jwt_service.rb
+++ b/backend/AutoShop/app/services/jwt_service.rb
@@ -1,0 +1,43 @@
+require "jwt"
+
+class JwtService
+  class DecodeError < StandardError; end
+
+  ALGORITHM   = "HS256".freeze #HMAC SHA-256 алг шифрования
+  DEFAULT_TTL = 24.hours #время жизни токена
+
+  # Методы класса
+  class << self
+    def encode(account:, ttl: DEFAULT_TTL)
+      issued_at  = Time.current
+      expires_at = issued_at + ttl
+
+      payload = {
+        sub:  account.id,
+        role: account.role,
+        jti:  SecureRandom.uuid,
+        iat:  issued_at.to_i,
+        exp:  expires_at.to_i
+      }
+
+      token = JWT.encode(payload, secret_key, ALGORITHM)
+      { token: token, payload: payload, expires_at: expires_at }
+    end
+
+    def decode(token)
+      payload, = JWT.decode(token, secret_key, true, { algorithm: ALGORITHM })
+      payload.with_indifferent_access
+    rescue JWT::DecodeError => e
+      raise DecodeError, e.message
+    end
+
+    private
+
+    def secret_key
+      ENV.fetch("JWT_SECRET_KEY") do
+        Rails.application.credentials.secret_key_base ||
+          Rails.application.secret_key_base
+      end
+    end
+  end
+end

--- a/backend/AutoShop/config/initializers/cors.rb
+++ b/backend/AutoShop/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV.fetch("FRONTEND_ORIGINS", "http://localhost:3001 http://localhost:5173").split
+
+    resource "*",
+             headers: :any,
+             expose:  %w[Authorization],
+             methods: %i[get post put patch delete options head],
+             credentials: false
+  end
+end

--- a/backend/AutoShop/config/routes.rb
+++ b/backend/AutoShop/config/routes.rb
@@ -9,6 +9,14 @@ Rails.application.routes.draw do
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
+  scope module: :api, defaults: { format: :json } do
+    scope :auth, as: :auth do
+      post "sign-up", to: "auth#sign_up", as: :sign_up
+      post "sign-in", to: "auth#sign_in", as: :sign_in
+      post "logout",  to: "auth#logout",  as: :logout
+    end
+  end
+
   # Defines the root path route ("/")
   # root "posts#index"
 end

--- a/backend/AutoShop/test/controllers/api/auth_controller_test.rb
+++ b/backend/AutoShop/test/controllers/api/auth_controller_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+module Api
+  class AuthControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @password = "Sup3rSecret!"
+      @account  = Account.create!(email: "user@example.com", password: @password)
+    end
+
+    test "POST /auth/sign-up creates account and returns token" do
+      assert_difference "Account.count", 1 do
+        post auth_sign_up_path, params: { email: "new@example.com", password: "Sup3rSecret!" }, as: :json
+      end
+
+      assert_response :created
+      body = response.parsed_body
+      assert body["token"].present?, "Expected a JWT in response"
+
+      payload = JwtService.decode(body["token"])
+      created = Account.find_by(email: "new@example.com")
+      assert_equal created.id, payload[:sub]
+      assert_equal "user", payload[:role]
+    end
+
+    test "POST /auth/sign-up returns 400 on duplicate email" do
+      post auth_sign_up_path, params: { email: @account.email, password: "OtherPass1" }, as: :json
+
+      assert_response :bad_request
+      assert_equal "validation_error", response.parsed_body["error"]
+    end
+
+    test "POST /auth/sign-up returns 400 on short password" do
+      post auth_sign_up_path, params: { email: "x@example.com", password: "123" }, as: :json
+
+      assert_response :bad_request
+      assert_equal "validation_error", response.parsed_body["error"]
+    end
+
+    test "POST /auth/sign-in returns token on valid credentials" do
+      post auth_sign_in_path, params: { email: @account.email, password: @password }, as: :json
+
+      assert_response :ok
+      assert response.parsed_body["token"].present?
+    end
+
+    test "POST /auth/sign-in returns 401 on wrong password" do
+      post auth_sign_in_path, params: { email: @account.email, password: "wrong" }, as: :json
+
+      assert_response :unauthorized
+      assert_equal "unauthorized", response.parsed_body["error"]
+    end
+
+    test "POST /auth/sign-in returns 401 on unknown email" do
+      post auth_sign_in_path, params: { email: "ghost@example.com", password: @password }, as: :json
+
+      assert_response :unauthorized
+    end
+
+    test "POST /auth/logout revokes token and rejects subsequent use" do
+      token = JwtService.encode(account: @account)[:token]
+      headers = { "Authorization" => "Bearer #{token}" }
+
+      post auth_logout_path, headers: headers
+      assert_response :ok
+      assert JwtDenylist.exists?(jti: JwtService.decode(token)[:jti])
+
+      post auth_logout_path, headers: headers
+      assert_response :unauthorized
+    end
+
+    test "POST /auth/logout without token returns 401" do
+      post auth_logout_path
+      assert_response :unauthorized
+    end
+  end
+end

--- a/docs/backend/auth.md
+++ b/docs/backend/auth.md
@@ -1,0 +1,103 @@
+# Auth API (issue #9)
+
+Реализация группы **Auth** по [OpenAPI 1.0.0](../api/openapi.yaml). Закрывает [issue #9](https://github.com/GHKaktus/AutoShop/issues/9).
+
+## Эндпоинты
+
+| Метод | URL | Аутентификация | Описание |
+|-------|-----|----------------|----------|
+| `POST` | `/auth/sign-up` | — | Регистрация. Возвращает JWT |
+| `POST` | `/auth/sign-in` | — | Авторизация. Возвращает JWT |
+| `POST` | `/auth/logout`  | `Bearer JWT` | Отзыв текущего токена |
+
+### `POST /auth/sign-up`
+
+Тело запроса (`application/json`):
+```json
+{ "email": "user@example.com", "password": "MySecurePassword123" }
+```
+
+Ответы:
+- `201 Created` → `{ "token": "<JWT>" }`
+- `400 Bad Request` → `{ "error": "validation_error", "message": "..." }` (email уже занят, пароль короче 6 символов, неверный формат email).
+
+### `POST /auth/sign-in`
+
+Тело запроса:
+```json
+{ "email": "user@example.com", "password": "MySecurePassword123" }
+```
+
+Ответы:
+- `200 OK` → `{ "token": "<JWT>" }`
+- `401 Unauthorized` → `{ "error": "unauthorized", "message": "Неверный email или пароль" }`.
+
+### `POST /auth/logout`
+
+Заголовок: `Authorization: Bearer <JWT>`.
+
+Ответы:
+- `200 OK` — токен добавлен в `JwtDenylist`, последующие запросы с ним отклоняются.
+- `401 Unauthorized` — токен отсутствует / уже отозван / просрочен.
+
+## JWT-формат
+
+Алгоритм: **HS256**. Срок жизни: **24 часа** (`JwtService::DEFAULT_TTL`).
+
+Payload:
+```json
+{
+  "sub": 42,                    // Account.id
+  "role": "user" | "admin",
+  "jti": "uuid-v4",             // нужен для денилиста
+  "iat": 1717100000,
+  "exp": 1717186400
+}
+```
+
+Секрет берётся в порядке:
+1. `ENV["JWT_SECRET_KEY"]` (рекомендуется задать в `.env`);
+2. `Rails.application.credentials.secret_key_base`;
+3. `Rails.application.secret_key_base` (Rails 7.1+ fallback).
+
+## Аутентификация других контроллеров
+
+В `Api::BaseController` подключён concern `JwtAuthenticatable`. Чтобы защитить эндпоинт:
+
+```ruby
+class Api::BasketController < Api::BaseController
+  before_action :authenticate_account!
+end
+```
+
+Для проверки роли admin (issue #11):
+
+```ruby
+before_action :authenticate_account!, :require_admin!
+```
+
+## Роль admin
+
+В версии API 1.0.0 роль задаётся **хардкодом**:
+- Через `db:seed` создаётся пользователь `admin@autoshop.local` (только в development).
+- Вручную: `Account.find_by(email: "...").update!(role: :admin)`.
+
+Перевод выдачи роли на runtime-логику — issue [#12](https://github.com/GHKaktus/AutoShop/issues/12).
+
+## CORS
+
+Инициализатор `config/initializers/cors.rb` пропускает запросы с фронтенда. Origin-ы берутся из `ENV["FRONTEND_ORIGINS"]` (по умолчанию: `http://localhost:3001 http://localhost:5173`).
+
+## Тесты
+
+`backend/AutoShop/test/controllers/api/auth_controller_test.rb` — 8 кейсов: sign-up (успех / дубль / короткий пароль), sign-in (успех / неверный пароль / неизвестный email), logout (успех + повторный отказ / без токена).
+
+Запуск:
+```bash
+cd backend/AutoShop
+bin/rails test test/controllers/api/auth_controller_test.rb
+```
+
+## Очистка денилиста
+
+`JwtDenylist.purge_expired!` — удаляет записи с истёкшим `expires_at`. Можно повесить на `solid_queue` (см. `config/recurring.yml`) после реализации фоновых задач.


### PR DESCRIPTION
## Краткое описание

Реализация issue #9: API группы **Auth** по OpenAPI 1.0.0.

## Что сделано

- `POST /auth/sign-up` — регистрация пользователя (email + password), ответ `201` с JWT
- `POST /auth/sign-in` — авторизация, ответ `200` с JWT
- `POST /auth/logout` — отзыв текущего токена (Bearer JWT → `JwtDenylist`)
- `JwtService` — выдача и проверка JWT (HS256, TTL 24 ч)
- `JwtAuthenticatable` — concern для защиты будущих эндпоинтов (Basket, Admin)
- `Api::BaseController` — базовый JSON API-контроллер
- CORS-инициализатор для фронтенда (`localhost:3001`, `localhost:5173`)
- 8 интеграционных тестов — все проходят
- Документация: `docs/backend/auth.md`

## Связанные задачи

Closes #9

## План проверки

- [ ] `cd backend/AutoShop && bundle install`
- [x] `rails db:migrate` (если БД ещё не поднята)
- [x] `bin/rails test test/controllers/api/auth_controller_test.rb`
- [x] `rails s` и проверка в Swagger Editor / curl:
  - регистрация → получение токена
  - вход с тем же email/паролем
  - logout с заголовком `Authorization: Bearer <token>`
  - повторный logout → `401`
