### PR TITLE
Реализовать Base API (issue #8)

### DIFF
--- a/backend/AutoShop/app/controllers/api/catalog_controller.rb
+++ b/backend/AutoShop/app/controllers/api/catalog_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class CatalogController < BaseController
+    include Paginatable
+
+    def index
+      category = Category.find(params[:id])
+      scope = Product.where(category_id: category.id).order(:id)
+      page_scope = paginated_scope(scope)
+
+      render json: pagination_payload(
+        scope,
+        items: ProductSerializer.collection_as_json(page_scope)
+      )
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/api/products_controller.rb
+++ b/backend/AutoShop/app/controllers/api/products_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  class ProductsController < BaseController
+    def show
+      product = Product.find(params[:id])
+      render json: ProductSerializer.as_json(product)
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/api/search_controller.rb
+++ b/backend/AutoShop/app/controllers/api/search_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class SearchController < BaseController
+    include Paginatable
+
+    def index
+      query = params[:q].to_s.strip
+      raise ActionController::ParameterMissing, "q is required" if query.blank?
+
+      scope = Product.search(query).order(:id)
+      return render_not_found if scope.none?
+
+      page_scope = paginated_scope(scope)
+
+      render json: pagination_payload(
+        scope,
+        items: ProductSerializer.collection_as_json(page_scope)
+      )
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/concerns/paginatable.rb
+++ b/backend/AutoShop/app/controllers/concerns/paginatable.rb
@@ -1,0 +1,27 @@
+module Paginatable
+  extend ActiveSupport::Concern
+
+  PAGE_SIZE = 20
+
+  private
+
+  def requested_page
+    page = params.fetch(:page, 0).to_i
+    raise ActionController::ParameterMissing, "page must be greater or equal to 0" if page.negative?
+
+    page
+  end
+
+  def pagination_payload(scope, items:)
+    {
+      total_items: scope.count,
+      current_page: requested_page,
+      page_size: PAGE_SIZE,
+      items: items
+    }
+  end
+
+  def paginated_scope(scope)
+    scope.page(requested_page + 1).per(PAGE_SIZE)
+  end
+end

--- a/backend/AutoShop/app/controllers/spa_controller.rb
+++ b/backend/AutoShop/app/controllers/spa_controller.rb
@@ -1,0 +1,21 @@
+class SpaController < ApplicationController
+  skip_forgery_protection
+
+  def index
+    index_path = spa_index_path
+    return head :not_found unless index_path
+
+    send_file index_path, type: "text/html", disposition: "inline"
+  end
+
+  private
+
+  def spa_index_path
+    candidates = [
+      Rails.root.join("..", "..", "frontend", "dist", "index.html"),
+      Rails.root.join("..", "..", "frontend", "index.html")
+    ]
+
+    candidates.map(&:to_s).find { |path| File.exist?(path) }
+  end
+end

--- a/backend/AutoShop/app/serializers/product_serializer.rb
+++ b/backend/AutoShop/app/serializers/product_serializer.rb
@@ -1,0 +1,17 @@
+class ProductSerializer
+  def self.as_json(product)
+    {
+      id: product.id,
+      name: product.name,
+      cost: product.cost,
+      sale_cost: product.sale_cost,
+      picture: product.picture,
+      description: product.description,
+      stock: product.stock
+    }
+  end
+
+  def self.collection_as_json(products)
+    products.map { |product| as_json(product) }
+  end
+end

--- a/backend/AutoShop/config/routes.rb
+++ b/backend/AutoShop/config/routes.rb
@@ -4,12 +4,17 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+  get "/", to: "spa#index"
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   scope module: :api, defaults: { format: :json } do
+    get "catalog/:id", to: "catalog#index", as: :catalog
+    get "products/:id", to: "products#show", as: :product
+    get "search", to: "search#index", as: :search
+
     scope :auth, as: :auth do
       post "sign-up", to: "auth#sign_up", as: :sign_up
       post "sign-in", to: "auth#sign_in", as: :sign_in

--- a/backend/AutoShop/test/controllers/api/base_endpoints_test.rb
+++ b/backend/AutoShop/test/controllers/api/base_endpoints_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+module Api
+  class BaseEndpointsTest < ActionDispatch::IntegrationTest
+    setup do
+      @category = Category.create!(name: "Тестовая", slug: "testovaya", position: 1)
+      @other_category = Category.create!(name: "Другая", slug: "drugaya", position: 2)
+
+      25.times do |idx|
+        Product.create!(
+          category: @category,
+          name: "Фильтр #{idx}",
+          cost: 100 + idx,
+          sale_cost: -1,
+          stock: true,
+          description: "Описание #{idx}"
+        )
+      end
+
+      Product.create!(
+        category: @other_category,
+        name: "Масло синтетическое",
+        cost: 999,
+        sale_cost: 899,
+        stock: true
+      )
+    end
+
+    test "GET /catalog/:id returns paginated products" do
+      get catalog_path(@category.id), as: :json
+
+      assert_response :success
+      body = response.parsed_body
+      assert_equal 25, body["total_items"]
+      assert_equal 0, body["current_page"]
+      assert_equal 20, body["page_size"]
+      assert_equal 20, body["items"].size
+    end
+
+    test "GET /catalog/:id supports page param" do
+      get catalog_path(@category.id), params: { page: 1 }, as: :json
+
+      assert_response :success
+      assert_equal 5, response.parsed_body["items"].size
+      assert_equal 1, response.parsed_body["current_page"]
+    end
+
+    test "GET /catalog/:id returns 404 for missing category" do
+      get catalog_path(-1), as: :json
+      assert_response :not_found
+      assert_equal "not_found", response.parsed_body["error"]
+    end
+
+    test "GET /products/:id returns product" do
+      product = Product.first
+
+      get product_path(product.id), as: :json
+
+      assert_response :success
+      body = response.parsed_body
+      assert_equal product.id, body["id"]
+      assert_equal product.name, body["name"]
+      assert_equal product.cost, body["cost"]
+    end
+
+    test "GET /products/:id returns 404 for unknown product" do
+      get product_path(-1), as: :json
+      assert_response :not_found
+    end
+
+    test "GET /search returns results by query" do
+      get search_path, params: { q: "масло" }, as: :json
+
+      assert_response :success
+      body = response.parsed_body
+      assert_equal 1, body["total_items"]
+      assert_equal "Масло синтетическое", body["items"][0]["name"]
+    end
+
+    test "GET /search returns 404 when no products found" do
+      get search_path, params: { q: "неттакоготовара" }, as: :json
+      assert_response :not_found
+      assert_equal "not_found", response.parsed_body["error"]
+    end
+
+    test "GET /search returns 400 when query is missing" do
+      get search_path, as: :json
+      assert_response :bad_request
+      assert_equal "bad_request", response.parsed_body["error"]
+    end
+  end
+end

--- a/backend/AutoShop/test/controllers/spa_controller_test.rb
+++ b/backend/AutoShop/test/controllers/spa_controller_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class SpaControllerTest < ActionDispatch::IntegrationTest
+  test "GET / returns html file when spa index exists" do
+    get "/"
+
+    assert_response :success
+    assert_equal "text/html", response.media_type
+  end
+end

--- a/docs/backend/base.md
+++ b/docs/backend/base.md
@@ -1,0 +1,42 @@
+# Base API (issue #8)
+
+Реализация Base-группы по `docs/api/openapi.yaml`.
+
+## Эндпоинты
+
+- `GET /` — отдаёт HTML React SPA (`frontend/dist/index.html`, fallback: `frontend/index.html`).
+- `GET /catalog/:id?page=0` — товары категории с пагинацией по 20.
+- `GET /products/:id` — карточка товара.
+- `GET /search?q=...&page=0` — поиск по названию товара.
+
+## Пагинация
+
+- Размер страницы: `20`.
+- Параметр `page` — с нуля (как в OpenAPI).
+- Формат ответа:
+
+```json
+{
+  "total_items": 25,
+  "current_page": 0,
+  "page_size": 20,
+  "items": [ ... ]
+}
+```
+
+## Обработка ошибок
+
+- `400 bad_request` — если отсутствует `q` в `/search` или `page < 0`.
+- `404 not_found` — если не найдены категория/товар или в поиске нет результатов.
+
+## Тесты
+
+- `test/controllers/api/base_endpoints_test.rb`
+- `test/controllers/spa_controller_test.rb`
+
+Запуск:
+
+```bash
+cd backend/AutoShop
+bin/rails test test/controllers/api/base_endpoints_test.rb test/controllers/spa_controller_test.rb
+```


### PR DESCRIPTION
## Краткое описание

Реализована группа **Base** по спецификации OpenAPI (issue #8).

## Что сделано

- Добавлен GET / (SpaController) для отдачи React SPA.
- Реализован GET /catalog/:id с пагинацией:
  - page начинается с 0;
  - размер страницы — 20.
- Реализован GET /products/:id.
- Реализован GET /search?q=...&page=....
- Добавлены ProductSerializer и concern Paginatable.
- Добавлены интеграционные тесты:
  - 	est/controllers/api/base_endpoints_test.rb;
  - 	est/controllers/spa_controller_test.rb.
- Добавлена документация docs/backend/base.md.

Closes #8

## План проверки

- [ ] cd backend/AutoShop
- [ ] in/rails test test/controllers/api/base_endpoints_test.rb test/controllers/spa_controller_test.rb
- [ ] Проверить вручную:
  - [ ] GET / возвращает HTML;
  - [ ] GET /catalog/{id} возвращает 	otal_items/current_page/page_size/items;
  - [ ] GET /products/{id} отдаёт товар;
  - [ ] GET /search?q=масло возвращает результаты;
  - [ ] GET /search без q возвращает 400.
