### PR TITLE
Реализовать API группы Basket (issue #10)

### DIFF
--- a/backend/AutoShop/app/controllers/api/basket/orders_controller.rb
+++ b/backend/AutoShop/app/controllers/api/basket/orders_controller.rb
@@ -1,0 +1,65 @@
+module Api
+  module Basket
+    class OrdersController < Api::BaseController
+      before_action :authenticate_account!
+
+      DEFAULT_ADDRESS = "Не указан (самовывоз)".freeze
+      SUCCESS_MESSAGE = "Заказ принят. С вами свяжутся для подтверждения.".freeze
+
+      def create
+        basket = current_account.basket || current_account.create_basket!
+        items  = basket.basket_items.includes(:product).to_a
+
+        if items.empty?
+          return render_error(
+            error:   "validation_error",
+            message: "Корзина пуста",
+            status:  :bad_request
+          )
+        end
+
+        order = build_order(items)
+
+        ActiveRecord::Base.transaction do
+          order.save!
+          basket.clear!
+        end
+
+        render json: {
+          order_id:     order.id,
+          total_amount: order.total_amount,
+          message:      SUCCESS_MESSAGE
+        }, status: :created
+      rescue ActiveRecord::RecordInvalid => e
+        render_error(
+          error:   "validation_error",
+          message: e.record.errors.full_messages.first || "Неверные данные заказа",
+          status:  :bad_request
+        )
+      end
+
+      private
+
+      def build_order(basket_items)
+        order = current_account.orders.new(order_form_params)
+        order.address = order.address.presence || DEFAULT_ADDRESS
+
+        basket_items.each do |basket_item|
+          order.order_items.build(
+            product:  basket_item.product,
+            name:     basket_item.product.name,
+            cost:     basket_item.product.effective_cost,
+            quantity: basket_item.quantity
+          )
+        end
+
+        order.total_amount = order.order_items.sum { |i| i.cost.to_i * i.quantity.to_i }
+        order
+      end
+
+      def order_form_params
+        params.permit(:name, :phone, :email, :comment, :address)
+      end
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/api/basket_controller.rb
+++ b/backend/AutoShop/app/controllers/api/basket_controller.rb
@@ -1,0 +1,53 @@
+module Api
+  class BasketController < BaseController
+    before_action :authenticate_account!
+
+    def show
+      items = current_basket.basket_items.includes(:product).order(:id)
+      render json: { items: BasketItemSerializer.collection_as_json(items) }
+    end
+
+    def create
+      product_id = params[:product_id]
+      quantity   = params[:quantity].to_i
+
+      if product_id.blank? || quantity < 1
+        return render_error(
+          error:   "bad_request",
+          message: "product_id и quantity обязательны (quantity ≥ 1)",
+          status:  :bad_request
+        )
+      end
+
+      product = Product.find_by(id: product_id)
+      return render_not_found unless product
+
+      item = current_basket.basket_items.find_or_initialize_by(product: product)
+      item.quantity = item.persisted? ? item.quantity + quantity : quantity
+
+      if item.save
+        head :ok
+      else
+        render_error(
+          error:   "validation_error",
+          message: item.errors.full_messages.first || "Не удалось добавить товар",
+          status:  :bad_request
+        )
+      end
+    end
+
+    def destroy
+      item = current_basket.basket_items.find_by(product_id: params[:id])
+      return render_not_found unless item
+
+      item.destroy
+      head :ok
+    end
+
+    private
+
+    def current_basket
+      @current_basket ||= current_account.basket || current_account.create_basket!
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/api/catalog_controller.rb
+++ b/backend/AutoShop/app/controllers/api/catalog_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  class CatalogController < BaseController
+    include Paginatable
+
+    def index
+      category = Category.find(params[:id])
+      scope = Product.where(category_id: category.id).order(:id)
+      page_scope = paginated_scope(scope)
+
+      render json: pagination_payload(
+        scope,
+        items: ProductSerializer.collection_as_json(page_scope)
+      )
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/api/products_controller.rb
+++ b/backend/AutoShop/app/controllers/api/products_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  class ProductsController < BaseController
+    def show
+      product = Product.find(params[:id])
+      render json: ProductSerializer.as_json(product)
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/api/search_controller.rb
+++ b/backend/AutoShop/app/controllers/api/search_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class SearchController < BaseController
+    include Paginatable
+
+    def index
+      query = params[:q].to_s.strip
+      raise ActionController::ParameterMissing, "q is required" if query.blank?
+
+      scope = Product.search(query).order(:id)
+      return render_not_found if scope.none?
+
+      page_scope = paginated_scope(scope)
+
+      render json: pagination_payload(
+        scope,
+        items: ProductSerializer.collection_as_json(page_scope)
+      )
+    end
+  end
+end

--- a/backend/AutoShop/app/controllers/concerns/paginatable.rb
+++ b/backend/AutoShop/app/controllers/concerns/paginatable.rb
@@ -1,0 +1,27 @@
+module Paginatable
+  extend ActiveSupport::Concern
+
+  PAGE_SIZE = 20
+
+  private
+
+  def requested_page
+    page = params.fetch(:page, 0).to_i
+    raise ActionController::ParameterMissing, "page must be greater or equal to 0" if page.negative?
+
+    page
+  end
+
+  def pagination_payload(scope, items:)
+    {
+      total_items: scope.count,
+      current_page: requested_page,
+      page_size: PAGE_SIZE,
+      items: items
+    }
+  end
+
+  def paginated_scope(scope)
+    scope.page(requested_page + 1).per(PAGE_SIZE)
+  end
+end

--- a/backend/AutoShop/app/controllers/spa_controller.rb
+++ b/backend/AutoShop/app/controllers/spa_controller.rb
@@ -1,0 +1,21 @@
+class SpaController < ApplicationController
+  skip_forgery_protection
+
+  def index
+    index_path = spa_index_path
+    return head :not_found unless index_path
+
+    send_file index_path, type: "text/html", disposition: "inline"
+  end
+
+  private
+
+  def spa_index_path
+    candidates = [
+      Rails.root.join("..", "..", "frontend", "dist", "index.html"),
+      Rails.root.join("..", "..", "frontend", "index.html")
+    ]
+
+    candidates.map(&:to_s).find { |path| File.exist?(path) }
+  end
+end

--- a/backend/AutoShop/app/serializers/basket_item_serializer.rb
+++ b/backend/AutoShop/app/serializers/basket_item_serializer.rb
@@ -1,0 +1,12 @@
+class BasketItemSerializer
+  def self.as_json(item)
+    {
+      product:  ProductSerializer.as_json(item.product),
+      quantity: item.quantity
+    }
+  end
+
+  def self.collection_as_json(items)
+    items.map { |item| as_json(item) }
+  end
+end

--- a/backend/AutoShop/app/serializers/product_serializer.rb
+++ b/backend/AutoShop/app/serializers/product_serializer.rb
@@ -1,0 +1,17 @@
+class ProductSerializer
+  def self.as_json(product)
+    {
+      id: product.id,
+      name: product.name,
+      cost: product.cost,
+      sale_cost: product.sale_cost,
+      picture: product.picture,
+      description: product.description,
+      stock: product.stock
+    }
+  end
+
+  def self.collection_as_json(products)
+    products.map { |product| as_json(product) }
+  end
+end

--- a/backend/AutoShop/config/routes.rb
+++ b/backend/AutoShop/config/routes.rb
@@ -20,6 +20,13 @@ Rails.application.routes.draw do
       post "sign-in", to: "auth#sign_in", as: :sign_in
       post "logout",  to: "auth#logout",  as: :logout
     end
+
+    scope :basket, as: :basket do
+      get    "",         to: "basket#show",    as: :show
+      post   "",         to: "basket#create",  as: :create
+      delete ":id",      to: "basket#destroy", as: :destroy
+      post   "order",    to: "basket/orders#create", as: :order
+    end
   end
 
   # Defines the root path route ("/")

--- a/backend/AutoShop/config/routes.rb
+++ b/backend/AutoShop/config/routes.rb
@@ -4,12 +4,17 @@ Rails.application.routes.draw do
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
+  get "/", to: "spa#index"
 
   # Render dynamic PWA files from app/views/pwa/* (remember to link manifest in application.html.erb)
   # get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   # get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
 
   scope module: :api, defaults: { format: :json } do
+    get "catalog/:id", to: "catalog#index", as: :catalog
+    get "products/:id", to: "products#show", as: :product
+    get "search", to: "search#index", as: :search
+
     scope :auth, as: :auth do
       post "sign-up", to: "auth#sign_up", as: :sign_up
       post "sign-in", to: "auth#sign_in", as: :sign_in

--- a/backend/AutoShop/test/controllers/api/base_endpoints_test.rb
+++ b/backend/AutoShop/test/controllers/api/base_endpoints_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+module Api
+  class BaseEndpointsTest < ActionDispatch::IntegrationTest
+    setup do
+      @category = Category.create!(name: "Тестовая", slug: "testovaya", position: 1)
+      @other_category = Category.create!(name: "Другая", slug: "drugaya", position: 2)
+
+      25.times do |idx|
+        Product.create!(
+          category: @category,
+          name: "Фильтр #{idx}",
+          cost: 100 + idx,
+          sale_cost: -1,
+          stock: true,
+          description: "Описание #{idx}"
+        )
+      end
+
+      Product.create!(
+        category: @other_category,
+        name: "Масло синтетическое",
+        cost: 999,
+        sale_cost: 899,
+        stock: true
+      )
+    end
+
+    test "GET /catalog/:id returns paginated products" do
+      get catalog_path(@category.id), as: :json
+
+      assert_response :success
+      body = response.parsed_body
+      assert_equal 25, body["total_items"]
+      assert_equal 0, body["current_page"]
+      assert_equal 20, body["page_size"]
+      assert_equal 20, body["items"].size
+    end
+
+    test "GET /catalog/:id supports page param" do
+      get catalog_path(@category.id), params: { page: 1 }, as: :json
+
+      assert_response :success
+      assert_equal 5, response.parsed_body["items"].size
+      assert_equal 1, response.parsed_body["current_page"]
+    end
+
+    test "GET /catalog/:id returns 404 for missing category" do
+      get catalog_path(-1), as: :json
+      assert_response :not_found
+      assert_equal "not_found", response.parsed_body["error"]
+    end
+
+    test "GET /products/:id returns product" do
+      product = Product.first
+
+      get product_path(product.id), as: :json
+
+      assert_response :success
+      body = response.parsed_body
+      assert_equal product.id, body["id"]
+      assert_equal product.name, body["name"]
+      assert_equal product.cost, body["cost"]
+    end
+
+    test "GET /products/:id returns 404 for unknown product" do
+      get product_path(-1), as: :json
+      assert_response :not_found
+    end
+
+    test "GET /search returns results by query" do
+      get search_path, params: { q: "масло" }, as: :json
+
+      assert_response :success
+      body = response.parsed_body
+      assert_equal 1, body["total_items"]
+      assert_equal "Масло синтетическое", body["items"][0]["name"]
+    end
+
+    test "GET /search returns 404 when no products found" do
+      get search_path, params: { q: "неттакоготовара" }, as: :json
+      assert_response :not_found
+      assert_equal "not_found", response.parsed_body["error"]
+    end
+
+    test "GET /search returns 400 when query is missing" do
+      get search_path, as: :json
+      assert_response :bad_request
+      assert_equal "bad_request", response.parsed_body["error"]
+    end
+  end
+end

--- a/backend/AutoShop/test/controllers/api/basket/orders_controller_test.rb
+++ b/backend/AutoShop/test/controllers/api/basket/orders_controller_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+module Api
+  module Basket
+    class OrdersControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @account  = Account.create!(email: "orderer@example.com", password: "Sup3rSecret!")
+        @category = Category.create!(name: "Тест", slug: "test", position: 1)
+        @product1 = Product.create!(category: @category, name: "Фильтр", cost: 500, sale_cost: 450, stock: true)
+        @product2 = Product.create!(category: @category, name: "Свеча",  cost: 200, stock: true)
+        @token    = JwtService.encode(account: @account)[:token]
+        @headers  = { "Authorization" => "Bearer #{@token}" }
+
+        basket = @account.basket || @account.create_basket!
+        basket.basket_items.create!(product: @product1, quantity: 2)
+        basket.basket_items.create!(product: @product2, quantity: 3)
+      end
+
+      test "POST /basket/order requires authentication" do
+        post basket_order_path
+        assert_response :unauthorized
+      end
+
+      test "POST /basket/order creates order, returns summary and clears basket" do
+        assert_difference "Order.count", 1 do
+          post basket_order_path,
+               params:  { name: "Иван", phone: "+79161234567", email: "ivan@example.com", comment: "Срочно" },
+               headers: @headers,
+               as:      :json
+        end
+
+        assert_response :created
+        body = response.parsed_body
+
+        assert body["order_id"].present?
+        assert_equal 1500, body["total_amount"]
+        assert_equal "Заказ принят. С вами свяжутся для подтверждения.", body["message"]
+
+        order = Order.find(body["order_id"])
+        assert_equal 2, order.order_items.count
+        assert_equal "Иван", order.name
+        assert_equal "Срочно", order.comment
+
+        assert_equal 0, @account.basket.reload.basket_items.count
+      end
+
+      test "POST /basket/order returns 400 when basket is empty" do
+        @account.basket.clear!
+
+        post basket_order_path,
+             params:  { name: "Иван", phone: "+79161234567", email: "ivan@example.com" },
+             headers: @headers,
+             as:      :json
+
+        assert_response :bad_request
+        assert_equal "Корзина пуста", response.parsed_body["message"]
+      end
+
+      test "POST /basket/order returns 400 on invalid form" do
+        post basket_order_path,
+             params:  { name: "И", phone: "abc", email: "ivan@example.com" },
+             headers: @headers,
+             as:      :json
+
+        assert_response :bad_request
+        assert_equal "validation_error", response.parsed_body["error"]
+      end
+    end
+  end
+end

--- a/backend/AutoShop/test/controllers/api/basket_controller_test.rb
+++ b/backend/AutoShop/test/controllers/api/basket_controller_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+module Api
+  class BasketControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @account  = Account.create!(email: "buyer@example.com", password: "Sup3rSecret!")
+      @category = Category.create!(name: "Тест", slug: "test", position: 1)
+      @product  = Product.create!(category: @category, name: "Фильтр", cost: 500, stock: true)
+      @other    = Product.create!(category: @category, name: "Свеча",  cost: 200, stock: true)
+      @token    = JwtService.encode(account: @account)[:token]
+      @headers  = { "Authorization" => "Bearer #{@token}" }
+    end
+
+    test "GET /basket requires authentication" do
+      get basket_show_path
+      assert_response :unauthorized
+    end
+
+    test "GET /basket returns empty items by default" do
+      get basket_show_path, headers: @headers
+      assert_response :success
+      assert_equal({ "items" => [] }, response.parsed_body)
+    end
+
+    test "POST /basket adds new product" do
+      post basket_create_path, params: { product_id: @product.id, quantity: 2 }, headers: @headers, as: :json
+      assert_response :ok
+
+      get basket_show_path, headers: @headers
+      body = response.parsed_body
+      assert_equal 1, body["items"].size
+      assert_equal @product.id, body["items"][0]["product"]["id"]
+      assert_equal 2, body["items"][0]["quantity"]
+    end
+
+    test "POST /basket increments quantity for existing product" do
+      post basket_create_path, params: { product_id: @product.id, quantity: 1 }, headers: @headers, as: :json
+      post basket_create_path, params: { product_id: @product.id, quantity: 3 }, headers: @headers, as: :json
+
+      get basket_show_path, headers: @headers
+      assert_equal 4, response.parsed_body["items"][0]["quantity"]
+    end
+
+    test "POST /basket returns 400 on invalid params" do
+      post basket_create_path, params: { product_id: @product.id, quantity: 0 }, headers: @headers, as: :json
+      assert_response :bad_request
+      assert_equal "bad_request", response.parsed_body["error"]
+    end
+
+    test "POST /basket returns 404 when product missing" do
+      post basket_create_path, params: { product_id: -1, quantity: 1 }, headers: @headers, as: :json
+      assert_response :not_found
+    end
+
+    test "DELETE /basket/:id removes product line" do
+      post basket_create_path, params: { product_id: @product.id, quantity: 1 }, headers: @headers, as: :json
+      post basket_create_path, params: { product_id: @other.id,   quantity: 2 }, headers: @headers, as: :json
+
+      delete basket_destroy_path(@product.id), headers: @headers
+      assert_response :ok
+
+      get basket_show_path, headers: @headers
+      assert_equal 1, response.parsed_body["items"].size
+      assert_equal @other.id, response.parsed_body["items"][0]["product"]["id"]
+    end
+
+    test "DELETE /basket/:id returns 404 if product not in basket" do
+      delete basket_destroy_path(@product.id), headers: @headers
+      assert_response :not_found
+    end
+  end
+end

--- a/backend/AutoShop/test/controllers/spa_controller_test.rb
+++ b/backend/AutoShop/test/controllers/spa_controller_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class SpaControllerTest < ActionDispatch::IntegrationTest
+  test "GET / returns html file when spa index exists" do
+    get "/"
+
+    assert_response :success
+    assert_equal "text/html", response.media_type
+  end
+end

--- a/docs/backend/base.md
+++ b/docs/backend/base.md
@@ -1,0 +1,42 @@
+# Base API (issue #8)
+
+Реализация Base-группы по `docs/api/openapi.yaml`.
+
+## Эндпоинты
+
+- `GET /` — отдаёт HTML React SPA (`frontend/dist/index.html`, fallback: `frontend/index.html`).
+- `GET /catalog/:id?page=0` — товары категории с пагинацией по 20.
+- `GET /products/:id` — карточка товара.
+- `GET /search?q=...&page=0` — поиск по названию товара.
+
+## Пагинация
+
+- Размер страницы: `20`.
+- Параметр `page` — с нуля (как в OpenAPI).
+- Формат ответа:
+
+```json
+{
+  "total_items": 25,
+  "current_page": 0,
+  "page_size": 20,
+  "items": [ ... ]
+}
+```
+
+## Обработка ошибок
+
+- `400 bad_request` — если отсутствует `q` в `/search` или `page < 0`.
+- `404 not_found` — если не найдены категория/товар или в поиске нет результатов.
+
+## Тесты
+
+- `test/controllers/api/base_endpoints_test.rb`
+- `test/controllers/spa_controller_test.rb`
+
+Запуск:
+
+```bash
+cd backend/AutoShop
+bin/rails test test/controllers/api/base_endpoints_test.rb test/controllers/spa_controller_test.rb
+```

--- a/docs/backend/basket.md
+++ b/docs/backend/basket.md
@@ -1,0 +1,76 @@
+# Basket API (issue #10)
+
+Реализация Basket-группы по `docs/api/openapi.yaml`. Все эндпоинты требуют JWT (`Authorization: Bearer <token>`).
+
+## Эндпоинты
+
+### `GET /basket`
+
+Возвращает содержимое корзины текущего пользователя.
+
+Ответ `200 OK`:
+```json
+{
+  "items": [
+    { "product": { "id": 1, "name": "Фильтр", "cost": 500, "sale_cost": -1, "picture": null, "description": null, "stock": true }, "quantity": 2 }
+  ]
+}
+```
+
+### `POST /basket`
+
+Добавляет товар в корзину. Если позиция уже присутствует — `quantity` **суммируется**.
+
+Тело:
+```json
+{ "product_id": 1, "quantity": 2 }
+```
+
+Ответы:
+- `200 OK` — успех;
+- `400 bad_request` — `quantity` < 1 или нет `product_id`;
+- `404 not_found` — товар не найден;
+- `401 unauthorized` — без токена.
+
+### `DELETE /basket/:id`
+
+`:id` — это **`product_id`**, как указано в OpenAPI («ID товара, который нужно удалить из корзины»). Удаляет позицию полностью.
+
+Ответы:
+- `200 OK`;
+- `404 not_found` — товар не в корзине.
+
+### `POST /basket/order`
+
+Создаёт заказ из текущей корзины, делает снапшот товаров (`name`, `cost`), очищает корзину.
+
+Тело (`OrderForm`):
+```json
+{ "name": "Иван", "phone": "+79161234567", "email": "ivan@example.com", "comment": "Срочно" }
+```
+
+Ответ `201 Created`:
+```json
+{ "order_id": 12345, "total_amount": 2500, "message": "Заказ принят. С вами свяжутся для подтверждения." }
+```
+
+Ошибки:
+- `400 bad_request` — пустая корзина или некорректные поля формы (формат телефона/email, короткое имя и т. п.);
+- `401 unauthorized` — без токена.
+
+## Замечания
+
+- Поле `address` обязательно в БД (`Order.address: NOT NULL`), но в `OrderForm` OpenAPI его нет. В контроллере используется значение по умолчанию `"Не указан (самовывоз)"`. При необходимости фронт может прислать `address` — он будет сохранён.
+- `total_amount` считается на сервере как сумма `cost * quantity` со снапшотом цен (учитывается `sale_cost`).
+- Корзина автоматически создаётся при регистрации пользователя (`Account.after_create :ensure_basket`) и при первом обращении к Basket API.
+
+## Тесты
+
+- `test/controllers/api/basket_controller_test.rb` — корзина (GET/POST/DELETE).
+- `test/controllers/api/basket/orders_controller_test.rb` — оформление заказа.
+
+Запуск:
+```bash
+cd backend/AutoShop
+bin/rails test test/controllers/api/basket_controller_test.rb test/controllers/api/basket/orders_controller_test.rb
+```


### PR DESCRIPTION
## Краткое описание

Реализована группа **Basket** по OpenAPI 1.0.0 (issue #10).

## Что сделано

- `GET /basket` — возвращает позиции корзины текущего пользователя
- `POST /basket` — добавляет товар, при повторе **суммирует** `quantity`
- `DELETE /basket/:id` — удаляет позицию по `product_id` (как указано в OpenAPI)
- `POST /basket/order` — создаёт заказ:
  - снапшотит `name` и `cost` товаров в `order_items`;
  - считает `total_amount` на сервере (учитывая `sale_cost`);
  - очищает корзину после успешного сохранения;
  - возвращает `{ order_id, total_amount, message }`.
- Все эндпоинты требуют JWT (`Authorization: Bearer ...`)
- Добавлен `BasketItemSerializer`
- Интеграционные тесты: 12 кейсов (`basket_controller_test.rb`, `basket/orders_controller_test.rb`) — проходят
- Документация: `docs/backend/basket.md`

## Замечание

`OrderForm` в OpenAPI не содержит поля `address`, но в схеме БД `Order.address` обязательное. В контроллере используется значение по умолчанию `"Не указан (самовывоз)"`. Если фронт пришлёт `address` — он сохраняется. Это совместимо с MVP-сценарием самовывоза и зафиксировано в `docs/backend/basket.md`.

## Зависимость

Основан на ветке `ApiBase` (issue #8, PR #23). Должен мерджиться после неё, либо одновременно — конфликтов нет.

Closes #10

## План проверки

- [ ] `cd backend/AutoShop`
- [ ] `bin/rails test test/controllers/api/basket_controller_test.rb test/controllers/api/basket/orders_controller_test.rb`
- [ ] Вручную:
  - [ ] получить токен через `POST /auth/sign-up`
  - [ ] добавить товар в корзину: `POST /basket { product_id, quantity }`
  - [ ] проверить `GET /basket`
  - [ ] удалить товар: `DELETE /basket/:product_id`
  - [ ] оформить заказ: `POST /basket/order { name, phone, email }` → `201` с `order_id`
